### PR TITLE
Show total count on "Alle" button; remove inline comment

### DIFF
--- a/src/item-list-card.js
+++ b/src/item-list-card.js
@@ -928,8 +928,6 @@ _parseShowMoreButtons() {
                       )
                     : ''}
         
-                  <!-- Default increment button (keeps existing behaviour using SHOW_MORE_AMOUNT)
-                        only show when it would show at least 1 new item -->
                   ${this.SHOW_MORE_AMOUNT <= remaining ? html`
                     <button
                       class="key-btn"
@@ -948,7 +946,7 @@ _parseShowMoreButtons() {
                     title="Alles anzeigen"
                     @click=${() => this._showMore('all')}
                   >
-                    Alle
+                    Alle (${this._fullItemsList.length})
                   </button>
                 </div>
               `;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The “All” filter button now displays the total number of items (e.g., “All (123)”), providing immediate visibility into list size and improving browsing clarity.
* **Chores**
  * Removed an obsolete inline comment with no impact on functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->