### PR TITLE
Filter spaces, raw compare, keep todo:key; remove inline comment

### DIFF
--- a/src/item-list-card.js
+++ b/src/item-list-card.js
@@ -412,6 +412,12 @@ class ItemListCard extends LitElement {
         return;
       }
   
+      // If the todo token is the only token present, clear it completely.
+      if (tokens.length === 1) {
+        this._updateFilterTextActual('');
+        return;
+      }
+
       // preserve only the todo:key token (keep original case)
       const preserved = tokens[todoTokenIndex];
   

--- a/src/item-list-card.js
+++ b/src/item-list-card.js
@@ -374,7 +374,7 @@ class ItemListCard extends LitElement {
       if (curRaw === valRaw) return;
   
       callService(this.hass, 'input_text', 'set_value',
-        { entity_id: entityId, value },
+        { entity_id: entityId, valRaw },
         this,
         'Fehler beim Aktualisieren des Suchfeldes');
     } catch (err) {

--- a/src/item-list-card.js
+++ b/src/item-list-card.js
@@ -929,7 +929,6 @@ _parseShowMoreButtons() {
                       )
                     : ''}
         
-                  <!-- Always show "Alle (N)" button to show the rest -->
                   <button
                     class="key-btn"
                     type="button"

--- a/src/item-list-card.js
+++ b/src/item-list-card.js
@@ -863,7 +863,7 @@ _parseShowMoreButtons() {
           <button
             class="btn ${!filterValue ? 'hidden' : ''}"
             type="button"
-            @click=${() => this._clearFilterPreservingTodoKey('')}
+            @click=${() => this._clearFilterPreservingTodoKey()}
             title="Eingabe leeren"
             aria-label="Eingabe leeren"
           >


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clicking a filter chip now inserts the token with a trailing space so you can continue typing immediately.
  * Clearing the filter preserves the selected todo key and leaves a trailing space to allow continued input without reselecting.
* **Bug Fixes**
  * Filter input reliably updates when values include trailing spaces, avoiding missed updates.
* **Style**
  * Minor whitespace and UI text cleanup with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->